### PR TITLE
Add tuple of floats as valid AMI array types

### DIFF
--- a/amitypes/array.py
+++ b/amitypes/array.py
@@ -90,4 +90,4 @@ class Array3d(metaclass=Array3dMeta):
     pass
 
 
-Array = typing.Union[Array3d, Array2d, Array1d, typing.List[float]]
+Array = typing.Union[Array3d, Array2d, Array1d, typing.List[float], typing.Tuple[float, ...]]


### PR DESCRIPTION
Make tuple of floats compatible with the AMI array type.
This should enable the compatibility between AMI boxes that return tuple with the Take box.